### PR TITLE
Add all of the non-corev1 validation for v1beta1

### DIFF
--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -20,9 +20,27 @@ import (
 	"context"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/serving"
 )
 
 // Validate makes sure that Configuration is properly configured.
 func (c *Configuration) Validate(ctx context.Context) *apis.FieldError {
+	return serving.ValidateObjectMetadata(c.GetObjectMeta()).ViaField("metadata").Also(
+		c.Spec.Validate(withinSpec(ctx)).ViaField("spec")).Also(
+		c.Status.Validate(withinStatus(ctx)).ViaField("status"))
+}
+
+// Validate implements apis.Validatable
+func (cs *ConfigurationSpec) Validate(ctx context.Context) *apis.FieldError {
+	return cs.Template.Validate(ctx).ViaField("template")
+}
+
+// Validate implements apis.Validatable
+func (cs *ConfigurationStatus) Validate(ctx context.Context) *apis.FieldError {
+	return cs.ConfigurationStatusFields.Validate(ctx)
+}
+
+// Validate implements apis.Validatable
+func (csf *ConfigurationStatusFields) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/apis"
+)
+
+func TestConfigurationValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *Configuration
+		want *apis.FieldError
+	}{{
+		name: "valid",
+		r: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
+						},
+					},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "invalid container concurrency",
+		r: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
+						},
+						ContainerConcurrency: -10,
+					},
+				},
+			},
+		},
+		want: apis.ErrOutOfBoundsValue(
+			-10, 0, RevisionContainerConcurrencyMax,
+			"spec.template.spec.containerConcurrency"),
+	}}
+
+	// TODO(dangerd): PodSpec validation failures.
+	// TODO(mattmoor): BYO Revision name.
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.r.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/contexts.go
+++ b/pkg/apis/serving/v1beta1/contexts.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import "context"
+
+type hdcn struct{}
+
+func withDefaultConfigurationName(ctx context.Context) context.Context {
+	return context.WithValue(ctx, hdcn{}, struct{}{})
+}
+
+func hasDefaultConfigurationName(ctx context.Context) bool {
+	return ctx.Value(hdcn{}) != nil
+}
+
+type inSpec struct{}
+
+func withinSpec(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inSpec{}, struct{}{})
+}
+
+func isInSpec(ctx context.Context) bool {
+	return ctx.Value(inSpec{}) != nil
+}
+
+type inStatus struct{}
+
+func withinStatus(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inStatus{}, struct{}{})
+}
+
+func isInStatus(ctx context.Context) bool {
+	return ctx.Value(inStatus{}) != nil
+}
+
+// TODO(mattmoor): Add something to attach the name of the parent object
+// to the context as a better way of validating BYO Revision name.

--- a/pkg/apis/serving/v1beta1/revision_validation.go
+++ b/pkg/apis/serving/v1beta1/revision_validation.go
@@ -20,9 +20,71 @@ import (
 	"context"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/kmp"
+	"github.com/knative/serving/pkg/apis/networking"
+	"github.com/knative/serving/pkg/apis/serving"
 )
 
 // Validate ensures Revision is properly configured.
-func (rt *Revision) Validate(ctx context.Context) *apis.FieldError {
+func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
+	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).ViaField("metadata")
+	errs = errs.Also(r.Spec.Validate(withinSpec(ctx)).ViaField("spec"))
+	errs = errs.Also(r.Status.Validate(withinStatus(ctx)).ViaField("status"))
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Revision)
+		if diff, err := kmp.SafeDiff(original.Spec, r.Spec); err != nil {
+			return &apis.FieldError{
+				Message: "Failed to diff Revision",
+				Paths:   []string{"spec"},
+				Details: err.Error(),
+			}
+		} else if diff != "" {
+			return &apis.FieldError{
+				Message: "Immutable fields changed (-old +new)",
+				Paths:   []string{"spec"},
+				Details: diff,
+			}
+		}
+	}
+
+	return errs
+}
+
+// Validate implements apis.Validatable
+func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
+	// TODO(mattmoor): Specialized ObjectMeta validation.
+	return rts.Spec.Validate(withinSpec(ctx)).ViaField("spec")
+}
+
+// Validate implements apis.Validatable
+func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
+	err := rs.ContainerConcurrency.Validate(ctx).ViaField("containerConcurrency")
+
+	// TODO(dangerd): Validate pod spec.
+
+	if rs.TimeoutSeconds != nil {
+		ts := *rs.TimeoutSeconds
+		max := int64(networking.DefaultTimeout.Seconds())
+		if ts < 0 || ts > max {
+			err = err.Also(apis.ErrOutOfBoundsValue(
+				ts, 0, max, "timeoutSeconds"))
+		}
+	}
+
+	return err
+}
+
+// Validate implements apis.Validatable.
+func (cc RevisionContainerConcurrencyType) Validate(ctx context.Context) *apis.FieldError {
+	if cc < 0 || cc > RevisionContainerConcurrencyMax {
+		return apis.ErrOutOfBoundsValue(
+			cc, 0, RevisionContainerConcurrencyMax, apis.CurrentField)
+	}
+	return nil
+}
+
+// Validate implements apis.Validatable
+func (rs *RevisionStatus) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -1,0 +1,477 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/serving/pkg/apis/networking"
+)
+
+func TestRevisionValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *Revision
+		want *apis.FieldError
+	}{{
+		name: "valid",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "invalid container concurrency",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
+				},
+				ContainerConcurrency: -10,
+			},
+		},
+		want: apis.ErrOutOfBoundsValue(
+			-10, 0, RevisionContainerConcurrencyMax,
+			"spec.containerConcurrency"),
+	}}
+
+	// TODO(dangerd): PodSpec validation failures.
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.r.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestContainerConcurrencyValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		cc   RevisionContainerConcurrencyType
+		want *apis.FieldError
+	}{{
+		name: "single",
+		cc:   1,
+		want: nil,
+	}, {
+		name: "unlimited",
+		cc:   0,
+		want: nil,
+	}, {
+		name: "ten",
+		cc:   10,
+		want: nil,
+	}, {
+		name: "invalid container concurrency (too small)",
+		cc:   -1,
+		want: apis.ErrOutOfBoundsValue(-1, 0, RevisionContainerConcurrencyMax,
+			apis.CurrentField),
+	}, {
+		name: "invalid container concurrency (too large)",
+		cc:   RevisionContainerConcurrencyMax + 1,
+		want: apis.ErrOutOfBoundsValue(RevisionContainerConcurrencyMax+1,
+			0, RevisionContainerConcurrencyMax, apis.CurrentField),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.cc.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func intptr(foo int64) *int64 {
+	return &foo
+}
+
+func TestRevisionSpecValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		rs   *RevisionSpec
+		want *apis.FieldError
+	}{{
+		name: "valid",
+		rs: &RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Image: "helloworld",
+				}},
+			},
+		},
+		want: nil,
+	}, {
+		name: "with volume (ok)",
+		rs: &RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Image: "helloworld",
+					VolumeMounts: []corev1.VolumeMount{{
+						MountPath: "/mount/path",
+						Name:      "the-name",
+						ReadOnly:  true,
+					}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name: "the-name",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "foo",
+						},
+					},
+				}},
+			},
+		},
+		want: nil,
+		// TODO(mattmoor): Validate PodSpec
+		// }, {
+		// 	name: "with volume name collision",
+		// 	rs: &RevisionSpec{
+		// 		PodSpec: corev1.PodSpec{
+		// 			Containers: []corev1.Container{{
+		// 				Image: "helloworld",
+		// 				VolumeMounts: []corev1.VolumeMount{{
+		// 					MountPath: "/mount/path",
+		// 					Name:      "the-name",
+		// 					ReadOnly:  true,
+		// 				}},
+		// 			}},
+		// 			Volumes: []corev1.Volume{{
+		// 				Name: "the-name",
+		// 				VolumeSource: corev1.VolumeSource{
+		// 					Secret: &corev1.SecretVolumeSource{
+		// 						SecretName: "foo",
+		// 					},
+		// 				},
+		// 			}, {
+		// 				Name: "the-name",
+		// 				VolumeSource: corev1.VolumeSource{
+		// 					ConfigMap: &corev1.ConfigMapVolumeSource{},
+		// 				},
+		// 			}},
+		// 		},
+		// 	},
+		// 	want: (&apis.FieldError{
+		// 		Message: fmt.Sprintf(`duplicate volume name "the-name"`),
+		// 		Paths:   []string{"name"},
+		// 	}).ViaFieldIndex("volumes", 1),
+		// }, {
+		// 	name: "bad pod spec",
+		// 	rs: &RevisionSpec{
+		// 		PodSpec: corev1.PodSpec{
+		// 			Containers: []corev1.Container{{
+		// 				Name:  "steve",
+		// 				Image: "helloworld",
+		// 			}},
+		// 		},
+		// 	},
+		// 	want: apis.ErrDisallowedFields("container.name"),
+	}, {
+		name: "exceed max timeout",
+		rs: &RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Image: "helloworld",
+				}},
+			},
+			TimeoutSeconds: intptr(6000),
+		},
+		want: apis.ErrOutOfBoundsValue(
+			6000, 0, networking.DefaultTimeout.Seconds(),
+			"timeoutSeconds"),
+	}, {
+		name: "negative timeout",
+		rs: &RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Image: "helloworld",
+				}},
+			},
+			TimeoutSeconds: intptr(-30),
+		},
+		want: apis.ErrOutOfBoundsValue(
+			-30, 0, networking.DefaultTimeout.Seconds(),
+			"timeoutSeconds"),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.rs.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestImmutableFields(t *testing.T) {
+	tests := []struct {
+		name string
+		new  *Revision
+		old  *Revision
+		want *apis.FieldError
+	}{{
+		name: "good (no change)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "bad (resources image change)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("cpu"): resource.MustParse("50m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("cpu"): resource.MustParse("100m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1beta1.RevisionSpec}.PodSpec.Containers[0].Resources.Requests["cpu"]:
+	-: resource.Quantity{i: resource.int64Amount{value: 100, scale: resource.Scale(-3)}, s: "100m", Format: resource.Format("DecimalSI")}
+	+: resource.Quantity{i: resource.int64Amount{value: 50, scale: resource.Scale(-3)}, s: "50m", Format: resource.Format("DecimalSI")}
+`,
+		},
+	}, {
+		name: "bad (container image change)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1beta1.RevisionSpec}.PodSpec.Containers[0].Image:
+	-: "busybox"
+	+: "helloworld"
+`,
+		},
+	}, {
+		name: "bad (concurrency model change)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+				ContainerConcurrency: 1,
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+				ContainerConcurrency: 2,
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1beta1.RevisionSpec}.ContainerConcurrency:
+	-: v1beta1.RevisionContainerConcurrencyType(2)
+	+: v1beta1.RevisionContainerConcurrencyType(1)
+`,
+		},
+	}, {
+		name: "bad (new field added)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+				ContainerConcurrency: 42,
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1beta1.RevisionSpec}.ContainerConcurrency:
+	-: v1beta1.RevisionContainerConcurrencyType(0)
+	+: v1beta1.RevisionContainerConcurrencyType(42)
+`,
+		},
+	}, {
+		name: "bad (multiple changes)",
+		new: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+				ContainerConcurrency: 2,
+			},
+		},
+		old: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
+				},
+				ContainerConcurrency: 4,
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: `{v1beta1.RevisionSpec}.PodSpec.Containers[0].Image:
+	-: "busybox"
+	+: "helloworld"
+{v1beta1.RevisionSpec}.ContainerConcurrency:
+	-: v1beta1.RevisionContainerConcurrencyType(4)
+	+: v1beta1.RevisionContainerConcurrencyType(2)
+`,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.old)
+			got := test.new.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/route_types.go
+++ b/pkg/apis/serving/v1beta1/route_types.go
@@ -59,7 +59,11 @@ var (
 
 // TrafficTarget holds a single entry of the routing table for a Route.
 type TrafficTarget struct {
-	// TODO(mattmoor): Add in whatever we end up calling "name"
+	// Name is optionally used to expose a dedicated hostname for referencing this
+	// target exclusively. It has the form: {name}.${route.status.domain}
+	// +optional
+	// TODO(mattmoor): Rename this.
+	Name string `json:"name,omitempty"`
 
 	// RevisionName of a specific revision to which to send this portion of traffic.
 	// This is mutually exclusive with ConfigurationName.

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -18,11 +18,153 @@ package v1beta1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/serving"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
+	return serving.ValidateObjectMetadata(r.GetObjectMeta()).ViaField("metadata").Also(
+		r.Spec.Validate(withinSpec(ctx)).ViaField("spec")).Also(
+		r.Status.Validate(withinStatus(ctx)).ViaField("status"))
+}
+
+func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// Track the targets of named TrafficTarget entries (to detect duplicates).
+	trafficMap := make(map[string]int)
+
+	sum := 0
+	for i, tt := range traffic {
+		errs = errs.Also(tt.Validate(ctx).ViaIndex(i))
+
+		if idx, ok := trafficMap[tt.Name]; ok {
+			// We want only single definition of the route, even if it points
+			// to the same config or revision.
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("Multiple definitions for %q", tt.Name),
+				Paths: []string{
+					fmt.Sprintf("[%d].name", i),
+					fmt.Sprintf("[%d].name", idx),
+				},
+			})
+		} else {
+			trafficMap[tt.Name] = i
+		}
+		sum += tt.Percent
+	}
+
+	if sum != 100 {
+		errs = errs.Also(&apis.FieldError{
+			Message: fmt.Sprintf("Traffic targets sum to %d, want 100", sum),
+			Paths:   []string{apis.CurrentField},
+		})
+	}
+	return errs
+}
+
+// Validate implements apis.Validatable
+func (rs *RouteSpec) Validate(ctx context.Context) *apis.FieldError {
+	return validateTrafficList(ctx, rs.Traffic).ViaField("traffic")
+}
+
+// Validate verifies that TrafficTarget is properly configured.
+func (tt *TrafficTarget) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// We only validate the sense of latestRevision in the context of a Spec,
+	// and only when it is specified.
+	if isInSpec(ctx) && tt.LatestRevision != nil {
+		lr := *tt.LatestRevision
+		pinned := tt.RevisionName != ""
+		if pinned == lr {
+			// The senses for whether to pin to a particular revision or
+			// float forward to the latest revision must match.
+			errs = errs.Also(apis.ErrInvalidValue(lr, "latestRevision"))
+		}
+	}
+
+	switch {
+	// When we have a default configurationName, we don't
+	// allow one to be specified.
+	case hasDefaultConfigurationName(ctx) && tt.ConfigurationName != "":
+		errs = errs.Also(apis.ErrDisallowedFields("configurationName"))
+
+	// Both revisionName and configurationName are never allowed to
+	// appear concurrently.
+	case tt.RevisionName != "" && tt.ConfigurationName != "":
+		errs = errs.Also(apis.ErrMultipleOneOf(
+			"revisionName", "configurationName"))
+
+	// When a revisionName appears, we must check that the name is valid.
+	case tt.RevisionName != "":
+		if el := validation.IsQualifiedName(tt.RevisionName); len(el) > 0 {
+			errs = errs.Also(apis.ErrInvalidKeyName(
+				tt.RevisionName, "revisionName", el...))
+		}
+
+	// When revisionName is missing in Status report an error.
+	case isInStatus(ctx):
+		errs = errs.Also(apis.ErrMissingField("revisionName"))
+
+	// When configurationName is specified, we must check that the name is valid.
+	case tt.ConfigurationName != "":
+		if el := validation.IsQualifiedName(tt.ConfigurationName); len(el) > 0 {
+			errs = errs.Also(apis.ErrInvalidKeyName(
+				tt.ConfigurationName, "configurationName", el...))
+		}
+
+	// When we are using a default configurationName, it must be a valid name already.
+	case hasDefaultConfigurationName(ctx):
+
+	// All other cases are missing one of revisionName or configurationName.
+	default:
+		errs = errs.Also(apis.ErrMissingOneOf(
+			"revisionName", "configurationName"))
+	}
+
+	// Check that the traffic Percentage is within bounds.
+	if tt.Percent < 0 || tt.Percent > 100 {
+		errs = errs.Also(apis.ErrOutOfBoundsValue(
+			tt.Percent, 0, 100, "percent"))
+	}
+
+	// Check that we set the URL appropriately.
+	if tt.URL != "" {
+		// URL is not allowed in traffic under spec.
+		if isInSpec(ctx) {
+			errs = errs.Also(apis.ErrDisallowedFields("url"))
+		}
+
+		// URL is not allowed in any traffic target without a name.
+		if tt.Name == "" {
+			errs = errs.Also(apis.ErrDisallowedFields("url"))
+		}
+	} else if tt.Name != "" {
+		// URL must be specified in status when name is specified.
+		if isInStatus(ctx) {
+			errs = errs.Also(apis.ErrMissingField("url"))
+		}
+	}
+
+	return errs
+}
+
+// Validate implements apis.Validatable
+func (rs *RouteStatus) Validate(ctx context.Context) *apis.FieldError {
+	return rs.RouteStatusFields.Validate(ctx)
+}
+
+// Validate implements apis.Validatable
+func (rsf *RouteStatusFields) Validate(ctx context.Context) *apis.FieldError {
+	// TODO(mattmoor): Validate other status fields.
+
+	if len(rsf.Traffic) != 0 {
+		return validateTrafficList(ctx, rsf.Traffic).ViaField("traffic")
+	}
 	return nil
 }

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -1,0 +1,466 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/apis"
+)
+
+func TestTrafficTargetValidation(t *testing.T) {
+	boolTrue := true
+	boolFalse := false
+
+	tests := []struct {
+		name string
+		tt   *TrafficTarget
+		want *apis.FieldError
+		wc   func(context.Context) context.Context
+	}{{
+		name: "valid with revisionName",
+		tt: &TrafficTarget{
+			RevisionName: "bar",
+			Percent:      12,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "valid with revisionName and name (spec)",
+		tt: &TrafficTarget{
+			Name:         "foo",
+			RevisionName: "bar",
+			Percent:      12,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "valid with revisionName and name (status)",
+		tt: &TrafficTarget{
+			Name:         "foo",
+			RevisionName: "bar",
+			Percent:      12,
+			URL:          "http://foo.bar.com",
+		},
+		wc:   withinStatus,
+		want: nil,
+	}, {
+		name: "invalid with revisionName and name (status)",
+		tt: &TrafficTarget{
+			Name:         "foo",
+			RevisionName: "bar",
+			Percent:      12,
+		},
+		wc:   withinStatus,
+		want: apis.ErrMissingField("url"),
+	}, {
+		name: "invalid with bad revisionName",
+		tt: &TrafficTarget{
+			RevisionName: "b ar",
+			Percent:      12,
+		},
+		wc: withinSpec,
+		want: apis.ErrInvalidKeyName(
+			"b ar", "revisionName", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
+	}, {
+		name: "valid with revisionName and latestRevision",
+		tt: &TrafficTarget{
+			RevisionName:   "bar",
+			LatestRevision: &boolFalse,
+			Percent:        12,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "invalid with revisionName and latestRevision (spec)",
+		tt: &TrafficTarget{
+			RevisionName:   "bar",
+			LatestRevision: &boolTrue,
+			Percent:        12,
+		},
+		wc:   withinSpec,
+		want: apis.ErrInvalidValue(true, "latestRevision"),
+	}, {
+		name: "valid with revisionName and latestRevision (status)",
+		tt: &TrafficTarget{
+			RevisionName:   "bar",
+			LatestRevision: &boolTrue,
+			Percent:        12,
+		},
+		wc:   withinStatus,
+		want: nil,
+	}, {
+		name: "valid with configurationName",
+		tt: &TrafficTarget{
+			ConfigurationName: "bar",
+			Percent:           37,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "valid with configurationName and name (spec)",
+		tt: &TrafficTarget{
+			Name:              "foo",
+			ConfigurationName: "bar",
+			Percent:           37,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "invalid with bad configurationName",
+		tt: &TrafficTarget{
+			ConfigurationName: "b ar",
+			Percent:           37,
+		},
+		wc: withinSpec,
+		want: apis.ErrInvalidKeyName(
+			"b ar", "configurationName", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
+	}, {
+		name: "valid with configurationName and latestRevision",
+		tt: &TrafficTarget{
+			ConfigurationName: "blah",
+			LatestRevision:    &boolTrue,
+			Percent:           37,
+		},
+		wc:   withinSpec,
+		want: nil,
+	}, {
+		name: "invalid with configurationName and latestRevision",
+		tt: &TrafficTarget{
+			ConfigurationName: "blah",
+			LatestRevision:    &boolFalse,
+			Percent:           37,
+		},
+		wc:   withinSpec,
+		want: apis.ErrInvalidValue(false, "latestRevision"),
+	}, {
+		name: "invalid with configurationName and default configurationName",
+		tt: &TrafficTarget{
+			ConfigurationName: "blah",
+			Percent:           37,
+		},
+		wc:   withDefaultConfigurationName,
+		want: apis.ErrDisallowedFields("configurationName"),
+	}, {
+		name: "valid with only default configurationName",
+		tt: &TrafficTarget{
+			Percent: 37,
+		},
+		wc: func(ctx context.Context) context.Context {
+			return withDefaultConfigurationName(withinSpec(ctx))
+		},
+		want: nil,
+	}, {
+		name: "valid with default configurationName and latestRevision",
+		tt: &TrafficTarget{
+			LatestRevision: &boolTrue,
+			Percent:        37,
+		},
+		wc: func(ctx context.Context) context.Context {
+			return withDefaultConfigurationName(withinSpec(ctx))
+		},
+		want: nil,
+	}, {
+		name: "invalid with default configurationName and latestRevision",
+		tt: &TrafficTarget{
+			LatestRevision: &boolFalse,
+			Percent:        37,
+		},
+		wc: func(ctx context.Context) context.Context {
+			return withDefaultConfigurationName(withinSpec(ctx))
+		},
+		want: apis.ErrInvalidValue(false, "latestRevision"),
+	}, {
+		name: "invalid without revisionName in status",
+		tt: &TrafficTarget{
+			ConfigurationName: "blah",
+			Percent:           37,
+		},
+		wc:   withinStatus,
+		want: apis.ErrMissingField("revisionName"),
+	}, {
+		name: "valid with revisionName and default configurationName",
+		tt: &TrafficTarget{
+			RevisionName: "bar",
+			Percent:      12,
+		},
+		wc:   withDefaultConfigurationName,
+		want: nil,
+	}, {
+		name: "valid with no percent",
+		tt: &TrafficTarget{
+			ConfigurationName: "booga",
+		},
+		want: nil,
+	}, {
+		name: "valid with no name",
+		tt: &TrafficTarget{
+			ConfigurationName: "booga",
+			Percent:           100,
+		},
+		want: nil,
+	}, {
+		name: "invalid with both",
+		tt: &TrafficTarget{
+			RevisionName:      "foo",
+			ConfigurationName: "bar",
+		},
+		want: &apis.FieldError{
+			Message: "expected exactly one, got both",
+			Paths:   []string{"revisionName", "configurationName"},
+		},
+	}, {
+		name: "invalid with neither",
+		tt: &TrafficTarget{
+			Percent: 100,
+		},
+		want: &apis.FieldError{
+			Message: "expected exactly one, got neither",
+			Paths:   []string{"revisionName", "configurationName"},
+		},
+	}, {
+		name: "invalid percent too low",
+		tt: &TrafficTarget{
+			RevisionName: "foo",
+			Percent:      -5,
+		},
+		want: apis.ErrOutOfBoundsValue("-5", "0", "100", "percent"),
+	}, {
+		name: "invalid percent too high",
+		tt: &TrafficTarget{
+			RevisionName: "foo",
+			Percent:      101,
+		},
+		want: apis.ErrOutOfBoundsValue("101", "0", "100", "percent"),
+	}, {
+		name: "disallowed url set",
+		tt: &TrafficTarget{
+			ConfigurationName: "foo",
+			Percent:           100,
+			URL:               "ShouldNotBeSet",
+		},
+		wc:   withinSpec,
+		want: apis.ErrDisallowedFields("url"),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.wc != nil {
+				ctx = test.wc(ctx)
+			}
+			got := test.tt.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestRouteValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *Route
+		want *apis.FieldError
+	}{{
+		name: "valid",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Name:         "bar",
+					RevisionName: "foo",
+					Percent:      100,
+				}},
+			},
+			Status: RouteStatus{
+				RouteStatusFields: RouteStatusFields{
+					Traffic: []TrafficTarget{{
+						Name:         "bar",
+						RevisionName: "foo",
+						Percent:      100,
+						URL:          "http://bar.blah.com",
+					}},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "valid split",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Name:         "prod",
+					RevisionName: "foo",
+					Percent:      90,
+				}, {
+					Name:              "experiment",
+					ConfigurationName: "bar",
+					Percent:           10,
+				}},
+			},
+		},
+		want: nil,
+	}, {
+		name: "missing url in status",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Name:         "bar",
+					RevisionName: "foo",
+					Percent:      100,
+				}},
+			},
+			Status: RouteStatus{
+				RouteStatusFields: RouteStatusFields{
+					Traffic: []TrafficTarget{{
+						Name:         "bar",
+						RevisionName: "foo",
+						Percent:      100,
+					}},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "missing field(s)",
+			Paths: []string{
+				"status.traffic[0].url",
+			},
+		},
+	}, {
+		name: "invalid traffic entry (missing oneof)",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Name:    "foo",
+					Percent: 100,
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "expected exactly one, got neither",
+			Paths: []string{
+				"spec.traffic[0].configurationName",
+				"spec.traffic[0].revisionName",
+			},
+		},
+	}, {
+		name: "invalid traffic entry (multiple names)",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Name:         "foo",
+					RevisionName: "bar",
+					Percent:      50,
+				}, {
+					Name:         "foo",
+					RevisionName: "bar",
+					Percent:      50,
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: `Multiple definitions for "foo"`,
+			Paths: []string{
+				"spec.traffic[0].name",
+				"spec.traffic[1].name",
+			},
+		},
+	}, {
+		name: "invalid name - dots",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					RevisionName: "foo",
+					Percent:      100,
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+			Paths:   []string{"metadata.name"},
+		},
+	}, {
+		name: "invalid name - dots and spec percent is not 100",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "do.not.use.dots",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					RevisionName: "foo",
+					Percent:      90,
+				}},
+			},
+		},
+		want: (&apis.FieldError{
+			Message: "not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+			Paths:   []string{"metadata.name"},
+		}).Also(&apis.FieldError{
+			Message: "Traffic targets sum to 90, want 100",
+			Paths:   []string{"spec.traffic"},
+		}),
+	}, {
+		name: "invalid name - too long",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.Repeat("a", 64),
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					RevisionName: "foo",
+					Percent:      100,
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "not a DNS 1035 label: [must be no more than 63 characters]",
+			Paths:   []string{"metadata.name"},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.r.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/service_validation.go
+++ b/pkg/apis/serving/v1beta1/service_validation.go
@@ -20,9 +20,26 @@ import (
 	"context"
 
 	"github.com/knative/pkg/apis"
+	"github.com/knative/serving/pkg/apis/serving"
 )
 
 // Validate makes sure that Service is properly configured.
 func (s *Service) Validate(ctx context.Context) *apis.FieldError {
-	return nil
+	return serving.ValidateObjectMetadata(s.GetObjectMeta()).ViaField("metadata").Also(
+		s.Spec.Validate(withinSpec(ctx)).ViaField("spec")).Also(
+		s.Status.Validate(withinStatus(ctx)).ViaField("status"))
+}
+
+// Validate implements apis.Validatable
+func (ss *ServiceSpec) Validate(ctx context.Context) *apis.FieldError {
+	return ss.ConfigurationSpec.Validate(ctx).Also(
+		// Within the context of Service, the RouteSpec has a default
+		// configurationName.
+		ss.RouteSpec.Validate(withDefaultConfigurationName(ctx)))
+}
+
+// Validate implements apis.Validatable
+func (ss *ServiceStatus) Validate(ctx context.Context) *apis.FieldError {
+	return ss.ConfigurationStatusFields.Validate(ctx).Also(
+		ss.RouteStatusFields.Validate(ctx))
 }

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/apis"
+)
+
+func TestServiceValidation(t *testing.T) {
+	boolTrue := true
+	boolFalse := false
+
+	goodConfigSpec := ConfigurationSpec{
+		Template: RevisionTemplateSpec{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		r    *Service
+		want *apis.FieldError
+	}{{
+		name: "valid run latest",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: goodConfigSpec,
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						LatestRevision: &boolTrue,
+						Percent:        100,
+					}},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "valid release",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: goodConfigSpec,
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						Name:           "current",
+						LatestRevision: &boolFalse,
+						RevisionName:   "valid-00001",
+						Percent:        98,
+					}, {
+						Name:           "candidate",
+						LatestRevision: &boolFalse,
+						RevisionName:   "valid-00002",
+						Percent:        2,
+					}, {
+						Name:           "latest",
+						LatestRevision: &boolTrue,
+						Percent:        0,
+					}},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "invalid configurationName",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: goodConfigSpec,
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						ConfigurationName: "valid",
+						LatestRevision:    &boolTrue,
+						Percent:           100,
+					}},
+				},
+			},
+		},
+		want: apis.ErrDisallowedFields("spec.traffic[0].configurationName"),
+	}, {
+		name: "invalid latestRevision",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: goodConfigSpec,
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						RevisionName:   "valid",
+						LatestRevision: &boolTrue,
+						Percent:        100,
+					}},
+				},
+			},
+		},
+		want: apis.ErrInvalidValue(true, "spec.traffic[0].latestRevision"),
+	}, {
+		name: "invalid container concurrency",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Image: "busybox",
+								}},
+							},
+							ContainerConcurrency: -10,
+						},
+					},
+				},
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						LatestRevision: &boolTrue,
+						Percent:        100,
+					}},
+				},
+			},
+		},
+		want: apis.ErrOutOfBoundsValue(
+			-10, 0, RevisionContainerConcurrencyMax,
+			"spec.template.spec.containerConcurrency"),
+	}}
+
+	// TODO(dangerd): PodSpec validation failures.
+	// TODO(mattmoor): BYO revision name.
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.r.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This punts on the PodSpec pieces, for which we need the new strategy @dgerd is working on.

This employs a new strategy for context-sensitive validation.  See contexts.go for the helpers, which are used throughout.

This is based on #1 