### PR TITLE
golang format tools

### DIFF
--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	"context"
 	"math"
-	"testing"
 	"net/url"
+	"testing"
 
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -58,7 +58,7 @@ func TestProbe(t *testing.T) {
 	url := objects.Service.Status.URL.URL()
 
 	// This polls until we get a 200 with the right body.
-	assertServiceResourcesUpdated(t, clients, names, url , test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 
 	// Use log.Printf instead of t.Logf because we want to see failures
 	// inline with other logs instead of buffered until the end.


### PR DESCRIPTION
<!--golang format tools-->
<!--18b6d6d079ea3511ebda08cf31da9e29-->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign mattmoor
