### PR TITLE
golang format tools

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -823,13 +823,13 @@ func TestPickIndices(t *testing.T) {
 
 func TestAssignSlice(t *testing.T) {
 	trackers := []*podIPTracker{
-		&podIPTracker{
+		{
 			dest: "2",
 		},
-		&podIPTracker{
+		{
 			dest: "1",
 		},
-		&podIPTracker{
+		{
 			dest: "3",
 		},
 	}

--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -176,7 +176,7 @@ const (
 
 	// ContainerMissing defines the reason for marking container healthiness status
 	// as false if the a container image for the revision is missing.
-	ContainerMissing         = "ContainerMissing"
+	ContainerMissing = "ContainerMissing"
 )
 
 // MarkResourcesAvailableTrue marks ResourcesAvailable status on revision as True

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -278,20 +278,20 @@ func TestReconcile(t *testing.T) {
 	// two constant objects above, which means, that all tests must share
 	// the same namespace and revision name.
 	table := TableTest{{
-		Name: "bad workqueue key, Part I",
-		Key:  "too/many/parts",
+		Name:                    "bad workqueue key, Part I",
+		Key:                     "too/many/parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "bad workqueue key, Part II",
-		Key:  "too-few-parts",
+		Name:                    "bad workqueue key, Part II",
+		Key:                     "too-few-parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "key not found",
-		Key:  "foo/not-found",
+		Name:                    "key not found",
+		Key:                     "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "key not found",
-		Key:  "foo/not-found",
+		Name:                    "key not found",
+		Key:                     "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
 		Name: "steady state",

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -166,22 +166,22 @@ var (
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
-		Name: "bad workqueue key",
-		Key:  "too/many/parts",
+		Name:                    "bad workqueue key",
+		Key:                     "too/many/parts",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "key not found",
-		Key:  "foo/not-found",
+		Name:                    "key not found",
+		Key:                     "foo/not-found",
 		SkipNamespaceValidation: true,
 	}, {
-		Name: "skip ingress not matching class key",
+		Name:                    "skip ingress not matching class key",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			addAnnotations(ingress("no-virtualservice-yet", 1234),
 				map[string]string{networking.IngressClassAnnotationKey: "fake-controller"}),
 		},
 	}, {
-		Name: "create VirtualService matching Ingress",
+		Name:                    "create VirtualService matching Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("no-virtualservice-yet", 1234),
@@ -234,7 +234,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/no-virtualservice-yet",
 	}, {
-		Name: "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
+		Name:                    "observed generation is updated when error is encountered in reconciling, and ingress ready status is unknown",
 		SkipNamespaceValidation: true,
 		WantErr:                 true,
 		WithReactors: []clientgotesting.ReactionFunc{
@@ -305,7 +305,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "test-ns/reconcile-failed",
 	}, {
-		Name: "reconcile VirtualService to match desired one",
+		Name:                    "reconcile VirtualService to match desired one",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("reconcile-virtualservice", 1234),
@@ -416,7 +416,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_EnableAutoTLS(t *testing.T) {
 	table := TableTest{{
-		Name: "update Gateway to match newly created Ingress",
+		Name:                    "update Gateway to match newly created Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
@@ -484,7 +484,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name: "No preinstalled Gateways",
+		Name:                    "No preinstalled Gateways",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
@@ -532,7 +532,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		WantErr: true,
 		Key:     "test-ns/reconciling-ingress",
 	}, {
-		Name: "delete Ingress",
+		Name:                    "delete Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithFinalizers("reconciling-ingress", 1234, ingressTLS, []string{ingressFinalizer}),
@@ -553,7 +553,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name: "TLS Secret is not in the namespace of Istio gateway service",
+		Name:                    "TLS Secret is not in the namespace of Istio gateway service",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLSWithSecretNamespace("knative-serving")),
@@ -630,7 +630,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name: "Reconcile Target secret",
+		Name:                    "Reconcile Target secret",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLSWithSecretNamespace("knative-serving")),
@@ -731,7 +731,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		},
 		Key: "test-ns/reconciling-ingress",
 	}, {
-		Name: "Reconcile with autoTLS but cluster local visibilty, mesh only",
+		Name:                    "Reconcile with autoTLS but cluster local visibilty, mesh only",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithTLSClusterLocal("reconciling-ingress", 1234, ingressTLS),

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -269,7 +269,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 	expectedLabels := map[string]string{
 		serving.RouteLabelKey:          route.Name,
 		serving.RouteNamespaceLabelKey: route.Namespace,
-		"route": "test-route",
+		"route":                        "test-route",
 	}
 	if diff := cmp.Diff(expectedLabels, ci.Labels); diff != "" {
 		t.Errorf("Unexpected label diff (-want +got): %v", diff)

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -27,8 +27,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/watch"
 	"math/big"
 	"net"
 	"net/http"
@@ -37,6 +35,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/watch"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
<!--golang format tools-->
<!--547c9ed287444e25982adc0b5772beef-->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign mattmoor
